### PR TITLE
added loop through when selecting a program

### DIFF
--- a/src/menus/AutoMenu.cpp
+++ b/src/menus/AutoMenu.cpp
@@ -11,12 +11,16 @@ void increaseCurrentProgram()
 {
     if (currentProgram < AMOUNT_OF_PROGRAMS)
         currentProgram++;
+    else if (currentProgram == AMOUNT_OF_PROGRAMS)
+        currentProgram = 1;
 }
 
 void decreaseCurrentProgram()
 {
     if (currentProgram > 1)
         currentProgram--;
+    else if (currentProgram == 1)
+        currentProgram = AMOUNT_OF_PROGRAMS;
 }
 
 void increaseSpeed()


### PR DESCRIPTION
When increasing the program while on the last program, the menu loops to the first program. It also loops to the last from the first program